### PR TITLE
Delay minimap update timer to reduce most lag.

### DIFF
--- a/scripts/game_server_scripts/gui/minimap.dsc
+++ b/scripts/game_server_scripts/gui/minimap.dsc
@@ -168,7 +168,7 @@ minimap:
     - bossbar update <[bb]>_yaw title:<[yaw].color[65,0,0]><proc[spacing].context[-<[spacing]>]><[yaw_icon]><proc[spacing].context[<[spacing]>]> color:YELLOW
 
     - inject minimap.tab
-    - wait 2t
+    - wait 5t
 
   - flag player fort.minimap:!
   - if <server.current_bossbars.contains[<[bb]>]>:

--- a/scripts/game_server_scripts/gui/minimap.dsc
+++ b/scripts/game_server_scripts/gui/minimap.dsc
@@ -168,7 +168,7 @@ minimap:
     - bossbar update <[bb]>_yaw title:<[yaw].color[65,0,0]><proc[spacing].context[-<[spacing]>]><[yaw_icon]><proc[spacing].context[<[spacing]>]> color:YELLOW
 
     - inject minimap.tab
-    - wait 1t
+    - wait 2t
 
   - flag player fort.minimap:!
   - if <server.current_bossbars.contains[<[bb]>]>:


### PR DESCRIPTION
Should still run smoothly but further investigation is needed after current test session. This is a quick improvement.