### PR TITLE
Faster update rate for compass bossbar

### DIFF
--- a/scripts/game_server_scripts/gui/minimap.dsc
+++ b/scripts/game_server_scripts/gui/minimap.dsc
@@ -25,6 +25,14 @@ minimap:
     - define loc <player.location.round>
     - define yaw <[loc].yaw>
 
+    # just so you know, adding characters before/and after the title does change the offset. who would've guessed /s
+    - bossbar update <[bb]> title:<[title]> color:YELLOW
+    - bossbar update <[bb]>_yaw title:<[yaw].color[65,0,0]><proc[spacing].context[-<[spacing]>]><[yaw_icon]><proc[spacing].context[<[spacing]>]> color:YELLOW
+
+    - if <[loop_index].mod[5]> != 0:
+      - wait 1t
+      - while next
+
     #-marker
     - define marker_red   <[yaw].is[LESS].than[0].if_true[<[yaw].add[360]>].if_false[<[yaw]>].div[360].mul[255]>
     #this is minimap marker
@@ -163,12 +171,8 @@ minimap:
     - define spacing <map[1=7;2=10;3=13].get[<[yaw].length>]>
     #or: <element[16].sub[<[yaw].length.mul[3]>]>
 
-    # just so you know, adding characters before/and after the title does change the offset. who would've guessed /s
-    - bossbar update <[bb]> title:<[title]> color:YELLOW
-    - bossbar update <[bb]>_yaw title:<[yaw].color[65,0,0]><proc[spacing].context[-<[spacing]>]><[yaw_icon]><proc[spacing].context[<[spacing]>]> color:YELLOW
-
     - inject minimap.tab
-    - wait 5t
+    - wait 1t
 
   - flag player fort.minimap:!
   - if <server.current_bossbars.contains[<[bb]>]>:


### PR DESCRIPTION
This change keeps the same update rate for minimap and tablist map but increases the update rate for the compass on the top of the screen since its more noticable there is a delay when playing and turning direction.